### PR TITLE
Update Contrast runtime to 46

### DIFF
--- a/org.gnome.design.Contrast.json
+++ b/org.gnome.design.Contrast.json
@@ -1,7 +1,7 @@
 {
     "id": "org.gnome.design.Contrast",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "45",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
Update Contrast runtime to 46 because runtime 45 will be EOL on 2024-09-14.