### PR TITLE
runtime: Update to 49

### DIFF
--- a/org.gnome.design.Contrast.json
+++ b/org.gnome.design.Contrast.json
@@ -1,7 +1,7 @@
 {
     "id": "org.gnome.design.Contrast",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "47",
+    "runtime-version": "49",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
There are warnings in the cli output:

```
2025-10-17T16:23:05.021965Z  WARN ashpd::error: Hack! The parsing of the iface name has failed: iface Object does not exist at path “/org/freedesktop/portal/desktop/request/1_1574/ashpd_XrucqsjgKZ, error details Object does not exist at path “/org/freedesktop/portal/desktop/request/1_1574/ashpd_XrucqsjgKZ”
```

not sure if this is related to the runtime though.

Other than the previous item, it works as expected.